### PR TITLE
Make rangedweapons mod work with mobs

### DIFF
--- a/smob/mcl_mobs/combat.lua
+++ b/smob/mcl_mobs/combat.lua
@@ -524,10 +524,6 @@ function mob_class:on_punch(hitter, tflp, tool_capabilities, dir)
 	local player_pos = hitter:get_pos()
 
 	if is_player then
-		-- is mob out of reach?
-		if vector.distance(mob_pos, player_pos) > 3 then
-			return
-		end
 		-- is mob protected?
 		if self.protected and minetest.is_protected(mob_pos, hitter:get_player_name()) then
 			return

--- a/smob/mcl_mobs/init.lua
+++ b/smob/mcl_mobs/init.lua
@@ -309,7 +309,7 @@ function mcl_mobs.register_mob(name, def)
 			--default built in engine collision detection
 			self.is_mob = true
 			self.object:set_properties({
-				collide_with_objects = false,
+				collide_with_objects = true,
 			})
 
 			return self:mob_activate(staticdata, def, dtime)


### PR DESCRIPTION
These changes allow guns from rangedweapons to do damage to mobs from this modpack.
Enabling collision is needed because the bullets check for collision, so if thats disabled the bullets go through the mobs.
Removing distance check is needed because the bullet that hits the mob references straight to the player that fired it upon a hit. This means if a player is more than 3 blocks away, the bullet wont do any damage.